### PR TITLE
Readme.md - Issues Feedback link update to actual discussion thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ In this repository, you can find the [official GitHub public feedback discussion
 
 - [GitHub Codespaces (limited public beta)](https://github.com/features/codespaces) - :computer: [Codespaces Feedback](https://github.com/github/feedback/discussions/categories/codespaces-feedback)
 - [GitHub Discussions (public beta)](https://github.blog/2020-05-06-new-from-satellite-2020-github-codespaces-github-discussions-securing-code-in-private-repositories-and-more/#discussions) - [:speaking_head: Discussions Feedback](https://github.com/github/feedback/discussions/categories/discussions-feedback)
-- [GitHub Issues](https://github.com/features/issues) - [:octopus: Issues Feedback](https://github.com/features/issues)
+- [GitHub Issues](https://github.com/features/issues) - [:octopus: Issues Feedback](https://github.com/github/feedback/discussions/categories/issues-feedback)
 - [GitHub Mobile](https://github.com/mobile) - [:iphone: Mobile Feedback](https://github.com/github/feedback/discussions/categories/mobile-feedback)
 - [GitHub Sponsors](https://github.com/sponsors) - [:sparkling_heart: Sponsors Feedback](https://github.com/github/feedback/discussions/categories/sponsors-feedback)
 - :octocat: [General Feedback](https://github.com/github/feedback/discussions/categories/general-feedback)


### PR DESCRIPTION
**Issues Feedback** link set to actual feedback/discussion thread/link

All the feature's feedback link is correctly directed to its discussion page/link but **Issues Feedback** link is set to same link as the feature's landing page.

<img width="1373" alt="Screen Shot 2021-06-26 at 3 13 40 AM" src="https://user-images.githubusercontent.com/20278933/123487138-18a0dd00-d62d-11eb-8139-828f02d523ac.png">
