### PR TITLE
Add Repositories to the product info column

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In this repository, you can find the [official GitHub public feedback discussion
 |  🖼️  [Profile](https://github.com/github-community/community/discussions/categories/profile)  	| [GitHub Profile](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-profile/customizing-your-profile/about-your-profile) 	|
 | ✔️  [Pull Requests](https://github.com/github-community/community/discussions/categories/pull-requests) 	| [GitHub Pull Requests](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) 	|
 |  💖  [Sponsors](https://github.com/github-community/community/discussions/categories/sponsors) 	| [GitHub Sponsors](https://github.com/sponsors) 	|
-| :octocat:  [General Feedback](https://github.com/github-community/community/discussions/categories/general) 	| [GitHub Docs](https://docs.github.com/en) |
+| :octocat:  [General Feedback](https://github.com/github-community/community/discussions/categories/general) 	| [GitHub Docs](https://docs.github.com/en) and [GitHub Repositories](https://docs.github.com/en/repositories) |
 
 These discussions are where you can share suggestions for how the products should be improved and discuss those improvements with the community, including members of the GitHub product team. Check out [Making suggestions](#making-suggestions) to learn how to provide feedback.
 


### PR DESCRIPTION
This adds "GitHub Repositories" to the product info column of the General category, since there isn't a "Repositories" category.

We worry that customers won't know to post repositories feedback in the General category, and this would help them know it's the right thing to do.

If a dedicated Repositories category would be acceptable now, that would be even better!

Thanks!