### PR TITLE
Update codespaces.yml

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/codespaces.yml
+++ b/.github/DISCUSSION_TEMPLATE/codespaces.yml
@@ -1,6 +1,7 @@
 labels: [Codespaces]
 body:
 - type: dropdown
+  id: topic
   attributes:
     label: Select Topic Area
     description: What would you like to discuss?
@@ -13,6 +14,7 @@ body:
   validations:
     required: true
 - type: textarea
+  id: text
   attributes:
     label: Body
     description: Start your discussion!


### PR DESCRIPTION
Add `id` property to the form components for Codespaces. In order to pre-populate fields using query parameters, an ID must be set.

### Example

https://github.com/orgs/community/discussions/new?category=codespaces&text=test without the ID will show:

![image](https://github.com/community/community/assets/80130182/1fbbb95f-f319-4ef7-ad22-bdbc6dd0492c)

The same URl with the `id: text` property will prepopulate the `Body` field:

![image](https://github.com/community/community/assets/80130182/02dad7ea-b382-43ca-8b8a-7a66d1562faa)
