### PR TITLE
typo on permission name

### DIFF
--- a/.github/workflows/issue_projects_labeler.yml
+++ b/.github/workflows/issue_projects_labeler.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
 
 permissions:
-  discussion: write
+  discussions: write
   contents: read
 
 jobs:


### PR DESCRIPTION
Here is the documentation:
https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

It should be `discussions` with an `s`