### PR TITLE
Use require_relative to load files needed for the stale action

### DIFF
--- a/.github/actions/comment
+++ b/.github/actions/comment
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "./lib/github"
+require_relative "../lib/github"
 
 stale_label_id = "LA_kwDOEfmk4M8AAAABYVCU-g"
 owner = "community"

--- a/.github/lib/github.rb
+++ b/.github/lib/github.rb
@@ -3,8 +3,8 @@
 require "faraday"
 require "json"
 
-require "./lib/categories"
-require "./lib/discussions"
+require_relative "./categories"
+require_relative "./discussions"
 
 # A class to make it easier to send requests to the GitHub GraphQL endpoint
 class GitHub


### PR DESCRIPTION
Originally in my testing, I had the Action files in different locations. The PR changes the `require` statements so that they use the relative form and this now allows the files to be loaded properly. There's no change in output here, it will still just check how many discussions should be acted on, but not modify anything.