### PR TITLE
Add the comment text that will be used to comment on stale discussions

### DIFF
--- a/.github/actions/comment
+++ b/.github/actions/comment
@@ -8,6 +8,22 @@ owner = "community"
 repo = "community"
 only_these_categories = ["Copilot", "Projects and Issues", "Accessibility"]
 
+body =<<BODY
+🕒 **Stale Discussion Alert** 🕒
+
+This Discussion has been labeled as stale by an automated system for having no activity in the last 60 days. Please consider one the following actions:
+
+1️⃣ Close as Out of Date: If the topic is no longer relevant, close the Discussion as "out of date" at the bottom of the page.
+
+2️⃣ Provide More Information: Share additional details or context — or let the community know if you've found a solution on your own.
+
+3️⃣ Mark a Reply as Answer: If your question has been answered by a reply, mark the most helpful reply as the solution.
+
+Note: This stale notification will only apply to Discussions with the `Question` label. To learn more, see our recent stalebot announcement.
+
+Thank you for helping bring this Discussion to a resolution! 💬
+BODY
+
 categories = Category.all(owner:, repo:).select { |c| only_these_categories.include?(c.name) }
 
 categories.map do |category|
@@ -21,7 +37,7 @@ end
 # for initial testing, don't modify any discussions
 #categories.each do |category|
 #  category.discussions.each do |discussion|
-#    discussion.add_comment(body: "This is automated")
+#    discussion.add_comment(body: body)
 #    discussion.add_label(label_id: stale_label_id)
 #  end
 #end

--- a/.github/actions/comment
+++ b/.github/actions/comment
@@ -40,6 +40,6 @@ categories.each do |category|
     end
     #discussion.add_label(label_id: stale_label_id)
 
-    sleep 0.5
+    sleep 1
   end
 end

--- a/.github/actions/comment
+++ b/.github/actions/comment
@@ -32,6 +32,11 @@ end
 
 categories.each do |c|
   puts "#{c.name} has #{c.discussions.count} eligible discussion(s)"
+
+  c.discussions.each do |d|
+    puts "#{d.url} -- #{d.title}"
+  end
+  puts "----------"
 end
 
 # for initial testing, don't modify any discussions

--- a/.github/actions/comment
+++ b/.github/actions/comment
@@ -13,7 +13,7 @@ body =<<BODY
 
 This Discussion has been labeled as stale by an automated system for having no activity in the last 60 days. Please consider one the following actions:
 
-1️⃣ Close as Out of Date: If the topic is no longer relevant, close the Discussion as "out of date" at the bottom of the page.
+1️⃣ Close as Out of Date: If the topic is no longer relevant, close the Discussion as `out of date` at the bottom of the page.
 
 2️⃣ Provide More Information: Share additional details or context — or let the community know if you've found a solution on your own.
 

--- a/.github/actions/comment
+++ b/.github/actions/comment
@@ -6,7 +6,7 @@ require_relative "../lib/github"
 stale_label_id = "LA_kwDOEfmk4M8AAAABYVCU-g"
 owner = "community"
 repo = "community"
-only_these_categories = ["Copilot", "Projects and Issues", "Accessibility"]
+only_these_categories = ["Projects and Issues"]
 
 body =<<BODY
 🕒 **Stale Discussion Alert** 🕒
@@ -33,7 +33,8 @@ end
 categories.each do |category|
   category.discussions.each do |discussion|
     puts "#{discussion.url},#{discussion.title}"
-    discussion.add_comment(body: body)
-    discussion.add_label(label_id: stale_label_id)
+    result = discussion.add_comment(body: body)
+    puts result
+    #discussion.add_label(label_id: stale_label_id)
   end
 end

--- a/.github/actions/comment
+++ b/.github/actions/comment
@@ -36,5 +36,7 @@ categories.each do |category|
     result = discussion.add_comment(body: body)
     puts result
     #discussion.add_label(label_id: stale_label_id)
+
+    sleep 0.5
   end
 end

--- a/.github/actions/comment
+++ b/.github/actions/comment
@@ -36,10 +36,11 @@ categories.each do |category|
     result = discussion.add_comment(body: body)
     if errors = result.dig("errors")
       puts "#{errors.dig(0, "type")}: #{errors.dig(0, "message")}"
+      sleep 1.2
       next
     end
     #discussion.add_label(label_id: stale_label_id)
 
-    sleep 1
+    sleep 1.2
   end
 end

--- a/.github/actions/comment
+++ b/.github/actions/comment
@@ -6,7 +6,7 @@ require_relative "../lib/github"
 stale_label_id = "LA_kwDOEfmk4M8AAAABYVCU-g"
 owner = "community"
 repo = "community"
-only_these_categories = ["Projects and Issues"]
+only_these_categories = ["Copilot", "Projects and Issues", "Accessibility"]
 
 body =<<BODY
 🕒 **Stale Discussion Alert** 🕒
@@ -34,7 +34,10 @@ categories.each do |category|
   category.discussions.each do |discussion|
     puts "#{discussion.url},#{discussion.title}"
     result = discussion.add_comment(body: body)
-    puts result
+    if errors = result.dig("errors")
+      puts "#{errors.dig(0, "type")}: #{errors.dig(0, "message")}"
+      next
+    end
     #discussion.add_label(label_id: stale_label_id)
 
     sleep 0.5

--- a/.github/actions/comment
+++ b/.github/actions/comment
@@ -19,7 +19,7 @@ This Discussion has been labeled as dormant by an automated system for having no
 
 3️⃣ Mark a Reply as Answer: If your question has been answered by a reply, mark the most helpful reply as the solution.
 
-Note: This dormant notification will only apply to Discussions with the `Question` label. To learn more, see our [recent stalebot announcement](https://github.com/orgs/community/discussions/70478).
+Note: This dormant notification will only apply to Discussions with the `Question` label. To learn more, see our [recent announcement](https://github.com/orgs/community/discussions/70478).
 
 Thank you for helping bring this Discussion to a resolution! 💬
 BODY

--- a/.github/actions/comment
+++ b/.github/actions/comment
@@ -19,7 +19,7 @@ This Discussion has been labeled as stale by an automated system for having no a
 
 3️⃣ Mark a Reply as Answer: If your question has been answered by a reply, mark the most helpful reply as the solution.
 
-Note: This stale notification will only apply to Discussions with the `Question` label. To learn more, see our recent stalebot announcement.
+Note: This stale notification will only apply to Discussions with the `Question` label. To learn more, see our [recent stalebot announcement](https://github.com/orgs/community/discussions/70478).
 
 Thank you for helping bring this Discussion to a resolution! 💬
 BODY

--- a/.github/actions/comment
+++ b/.github/actions/comment
@@ -9,9 +9,9 @@ repo = "community"
 only_these_categories = ["Copilot"]
 
 body =<<BODY
-🕒 **Stale Discussion Alert** 🕒
+🕒 **Discussion Activity Reminder** 🕒
 
-This Discussion has been labeled as stale by an automated system for having no activity in the last 60 days. Please consider one the following actions:
+This Discussion has been labeled as dormant by an automated system for having no activity in the last 60 days. Please consider one the following actions:
 
 1️⃣ Close as Out of Date: If the topic is no longer relevant, close the Discussion as `out of date` at the bottom of the page.
 
@@ -19,7 +19,7 @@ This Discussion has been labeled as stale by an automated system for having no a
 
 3️⃣ Mark a Reply as Answer: If your question has been answered by a reply, mark the most helpful reply as the solution.
 
-Note: This stale notification will only apply to Discussions with the `Question` label. To learn more, see our [recent stalebot announcement](https://github.com/orgs/community/discussions/70478).
+Note: This dormant notification will only apply to Discussions with the `Question` label. To learn more, see our [recent stalebot announcement](https://github.com/orgs/community/discussions/70478).
 
 Thank you for helping bring this Discussion to a resolution! 💬
 BODY

--- a/.github/actions/comment
+++ b/.github/actions/comment
@@ -6,7 +6,7 @@ require_relative "../lib/github"
 stale_label_id = "LA_kwDOEfmk4M8AAAABYVCU-g"
 owner = "community"
 repo = "community"
-only_these_categories = ["Copilot", "Projects and Issues", "Accessibility"]
+only_these_categories = ["Copilot"]
 
 body =<<BODY
 🕒 **Stale Discussion Alert** 🕒

--- a/.github/actions/comment
+++ b/.github/actions/comment
@@ -30,19 +30,10 @@ categories.map do |category|
   category.discussions = Discussion.all(owner:, repo:, category:)
 end
 
-categories.each do |c|
-  puts "#{c.name} has #{c.discussions.count} eligible discussion(s)"
-
-  c.discussions.each do |d|
-    puts "#{d.url} -- #{d.title}"
+categories.each do |category|
+  category.discussions.each do |discussion|
+    puts "#{discussion.url},#{discussion.title}"
+    discussion.add_comment(body: body)
+    discussion.add_label(label_id: stale_label_id)
   end
-  puts "----------"
 end
-
-# for initial testing, don't modify any discussions
-#categories.each do |category|
-#  category.discussions.each do |discussion|
-#    discussion.add_comment(body: body)
-#    discussion.add_label(label_id: stale_label_id)
-#  end
-#end

--- a/.github/lib/discussions.rb
+++ b/.github/lib/discussions.rb
@@ -5,6 +5,8 @@ require "active_support/core_ext/numeric/time"
 
 Discussion = Struct.new(
   :id,
+  :url,
+  :title
 ) do
   def self.all(owner: nil, repo: nil, category: nil)
     return [] if owner.nil? || repo.nil? || category.nil?
@@ -21,6 +23,8 @@ Discussion = Struct.new(
         ) {
           nodes {
             id
+            url
+            title
             closed
             locked
             updatedAt
@@ -55,7 +59,9 @@ Discussion = Struct.new(
       .reject { |r| r.dig("labels", "nodes").map { |l| l["name"] }.include?("stale") }
       .map do |c|
         Discussion.new(
-          c["id"]
+          c["id"],
+          c["url"],
+          c["title"]
         )
       end
   end

--- a/.github/lib/discussions.rb
+++ b/.github/lib/discussions.rb
@@ -58,6 +58,7 @@ Discussion = Struct.new(
       .reject { |r| r["locked"] }
       .reject { |r| r.dig("comments", "totalCount") > 0 && Date.parse(r.dig("comments", "nodes", 0, "createdAt")).after?(cutoff_date) }
       #.reject { |r| r.dig("labels", "nodes").map { |l| l["name"] }.include?("stale") }
+      .select { |r| r.dig("labels", "nodes").map { |l| l["name"] }.include?("stale") }
       .map do |c|
         Discussion.new(
           c["id"],

--- a/.github/lib/discussions.rb
+++ b/.github/lib/discussions.rb
@@ -57,7 +57,7 @@ Discussion = Struct.new(
       .reject { |r| r["closed"] }
       .reject { |r| r["locked"] }
       .reject { |r| r.dig("comments", "totalCount") > 0 && Date.parse(r.dig("comments", "nodes", 0, "createdAt")).after?(cutoff_date) }
-      .reject { |r| r.dig("labels", "nodes").map { |l| l["name"] }.include?("stale") }
+      #.reject { |r| r.dig("labels", "nodes").map { |l| l["name"] }.include?("stale") }
       .map do |c|
         Discussion.new(
           c["id"],

--- a/.github/lib/discussions.rb
+++ b/.github/lib/discussions.rb
@@ -53,6 +53,7 @@ Discussion = Struct.new(
     GitHub.new.post(graphql: query).map! { |r| r.dig('discussions', 'nodes') }
       .flatten
       .reject { |r| Date.parse(r["updatedAt"]).after?(cutoff_date) }
+      .select { |r| r.dig("labels", "nodes").map { |l| l["name"] }.include?("Question") }
       .reject { |r| r["closed"] }
       .reject { |r| r["locked"] }
       .reject { |r| r.dig("comments", "totalCount") > 0 && Date.parse(r.dig("comments", "nodes", 0, "createdAt")).after?(cutoff_date) }

--- a/.github/lib/github.rb
+++ b/.github/lib/github.rb
@@ -27,6 +27,10 @@ class GitHub
       response = @conn.post("/graphql") do |req|
         req.body = { query: }.to_json
       end
+      unless response.status == 200
+        puts "#{response.reason_phrase}: #{JSON.parse(response.body).dig("message")}"
+        exit
+      end
 
       node = JSON.parse(response.body).dig("data", "repository")
       nodes << node


### PR DESCRIPTION
I've added in the comment text from https://github.com/github/customer-success-engineering/issues/1490#issuecomment-1756356610 and added some reporting so that we can see which discussions will be affected.

As of now, none of the discussions will be commented on, but once we're happy that we've targeted the correct ones, I can change that before merging this PR.

I'm going to run the Action manually from this branch before it can comment on any discussions to make sure that everything is working as expected.