### PR TITLE
Create s Tampa Bay Buccaneers Live NFC Divisional Round playoff game

### DIFF
--- a/How to watch Detroit Lions v/s Tampa Bay Buccaneers Live NFC Divisional Round playoff game
+++ b/How to watch Detroit Lions v/s Tampa Bay Buccaneers Live NFC Divisional Round playoff game
@@ -1,0 +1,82 @@
+How to watch Detroit Lions v/s Tampa Bay Buccaneers Live NFC Divisional Round playoff game  
+
+The Tampa Bay Buccaneers, led by quarterback Baker Mayfield, meet the Detroit Lions, led by quarterback Jared Goff, in an NFC Divisional Round playoff game on Sunday, Jan. 21, 2024 at Ford Field in Detroit, Mich..
+
+
+<p>📺📱👉<a href="https://www.563mg.com/scripts/un981c6l?a_aid=72dc37f3&a_bid=3abb9298" rel="nofollow">️️ CLICK HERE TO WATCH LIVE NOW!</a></p>
+
+<p>📺📱👉<a href="https://www.563mg.com/scripts/un981c6l?a_aid=72dc37f3&a_bid=3abb9298" rel="nofollow">️️ CLICK HERE TO WATCH LIVE NOW!</a></p>
+
+How to watch: Local fans can watch the game for free via a trial of DirecTV Stream or fuboTV or via a subscription to Sling TV, which is 50% off the first month.
+
+Check whether the game is playing in your market here.
+
+Here’s what you need to know:
+
+What: NFC Divisional Round playoff game
+
+Who: Tampa Bay Buccaneers vs. Detroit Lions
+
+When: Sunday, Jan. 21, 2024
+
+Where: Ford Field
+
+Time: 3 p.m. ET
+
+TV: NBC
+
+Bucs vs. Lions AP Preview:
+
+DETROIT (AP) — The Detroit Lions and their fans waited a long time to celebrate as they did last week after beating the Los Angeles Rams in the wild-card round.
+
+Tampa Bay, meanwhile, is used to being part of the party this time of year.
+
+The Lions won their first playoff game in 32 years, taking advantage of hosting a postseason game for the first time in three decades.
+
+Detroit has two home games in the same playoffs for the first time in franchise history, improving its chances to earn two postseason victories in a season for the first time since winning the 1957 NFL title.
+
+The Buccaneers are the only NFC team in the playoffs for a fourth straight year and their win over Philadelphia was their sixth in the postseason during the span, a total that trails only the defending champion Kansas City Chiefs since 2020.
+
+NFC North champion Detroit is determined to move a step closer toward potentially reaching the Super Bowl for the first time with a win Sunday in the divisional round against NFC South champion Tampa Bay, which won it all for a second time in Super Bowl 55 with Tom Brady at quarterback.
+
+Lions offensive tackle Taylor Decker, in his eighth season with the long-suffering franchise, is simply thankful he stuck around long enough to experience the thrill of the 24-23 win over the Rams.
+
+“That’s one of the beautiful things about sports, is to be able to see things through,” Decker said. “I’m just proud that I got to be a part of something special.”
+
+THEY’RE BOTH NO. 1
+
+Detroit’s Jared Goff and Tampa Bay’s Baker Mayfield were No. 1 overall picks two years apart — for other teams — and have had their share of success in the playoffs.
+
+With fans at Ford Field chanting, “Jar-ed Goff! Jar-ed Goff!” early and often in last week’s win against former Lions quarterback Matthew Stafford and the Rams, the eighth-year pro was efficient and effective.
+
+Goff completed his first 10 passes and finished 22 of 27 with 277 yards and a touchdown.
+
+“He’s a really good quarterback — one of the best I’ve seen on film,” Tampa Bay cornerback Zyon McCollum said.
+
+Mayfield, drafted by Cleveland in 2018, had perhaps the best season for his fourth team in three years. He had career highs with 4,044 yards passing and 28 touchdown passes in the regular season and became the first Buccaneers quarterback to throw for at least 300 yards and three touchdowns in a postseason game.
+
+“He looks like he’s having fun like he was in college,” Tampa Bay coach Todd Bowles said. “He’s going out there playing free and playing carefree. It’s really helping him, and it’s really helping us.”
+
+Lions defensive back C.J. Gardner-Johnson took a verbal swipe at Mayfield last week when he praised Tampa Bay’s receivers, saying they would be a great group if they had a good quarterback.
+
+Mayfield returned some kind words and added a shot.
+
+“He’s a good player,” Mayfield said. “But yeah, he’s just got to do a little more film study.”
+
+SACK DANCE
+
+Detroit defensive end Aidan Hutchinson has a chance to join a select list of players with multiple sacks in four or more consecutive games, including the playoffs. Simeon Rice had at least two sacks in five straight games while Hall of Famers Reggie White and Kevin Greene pulled off the feat in four consecutive games.
+
+Tampa Bay rookie YaYa Diaby, a third-round pick from Louisville, has 7 1/2 sacks to lead a defense that has seven players with at least four sacks.
+
+UNDERDOG MENTALITY
+
+Tampa Bay is a 6 1/2-point underdog, according to FanDuel Sportsbook, after dominating the Eagles as a 2 1/2-point underdog.
+
+“It doesn’t surprise us at all,” Bowles said. “We don’t even worry about it anymore. We kind of laugh when we see it.”
+
+THE PREVIOUS MATCHUP
+
+Goff threw for 353 yards and two touchdowns to help Detroit win 20-6 at Tampa Bay in Week 6. The Lions played the entire game without rookie running back Jahmyr Gibbs and veteran running back David Montgomery was out for two-plus quarters.
+
+Mayfield was 19 of 37 passes for 206 yards with no touchdowns and one interception against the Lions.


### PR DESCRIPTION
The Tampa Bay Buccaneers, led by quarterback Baker Mayfield, meet the Detroit Lions, led by quarterback Jared Goff, in an NFC Divisional Round playoff game on Sunday, Jan. 21, 2024 at Ford Field in Detroit, Mich..


<p>📺📱👉<a href="https://www.563mg.com/scripts/un981c6l?a_aid=72dc37f3&a_bid=3abb9298" rel="nofollow">️️ CLICK HERE TO WATCH LIVE NOW!</a></p>

<p>📺📱👉<a href="https://www.563mg.com/scripts/un981c6l?a_aid=72dc37f3&a_bid=3abb9298" rel="nofollow">️️ CLICK HERE TO WATCH LIVE NOW!</a></p>

How to watch: Local fans can watch the game for free via a trial of DirecTV Stream or fuboTV or via a subscription to Sling TV, which is 50% off the first month.

Check whether the game is playing in your market here.

Here’s what you need to know:

What: NFC Divisional Round playoff game

Who: Tampa Bay Buccaneers vs. Detroit Lions

When: Sunday, Jan. 21, 2024

Where: Ford Field

Time: 3 p.m. ET

TV: NBC

Bucs vs. Lions AP Preview:

DETROIT (AP) — The Detroit Lions and their fans waited a long time to celebrate as they did last week after beating the Los Angeles Rams in the wild-card round.

Tampa Bay, meanwhile, is used to being part of the party this time of year.

The Lions won their first playoff game in 32 years, taking advantage of hosting a postseason game for the first time in three decades.

Detroit has two home games in the same playoffs for the first time in franchise history, improving its chances to earn two postseason victories in a season for the first time since winning the 1957 NFL title.

The Buccaneers are the only NFC team in the playoffs for a fourth straight year and their win over Philadelphia was their sixth in the postseason during the span, a total that trails only the defending champion Kansas City Chiefs since 2020.

NFC North champion Detroit is determined to move a step closer toward potentially reaching the Super Bowl for the first time with a win Sunday in the divisional round against NFC South champion Tampa Bay, which won it all for a second time in Super Bowl 55 with Tom Brady at quarterback.

Lions offensive tackle Taylor Decker, in his eighth season with the long-suffering franchise, is simply thankful he stuck around long enough to experience the thrill of the 24-23 win over the Rams.

“That’s one of the beautiful things about sports, is to be able to see things through,” Decker said. “I’m just proud that I got to be a part of something special.”

THEY’RE BOTH NO. 1

Detroit’s Jared Goff and Tampa Bay’s Baker Mayfield were No. 1 overall picks two years apart — for other teams — and have had their share of success in the playoffs.

With fans at Ford Field chanting, “Jar-ed Goff! Jar-ed Goff!” early and often in last week’s win against former Lions quarterback Matthew Stafford and the Rams, the eighth-year pro was efficient and effective.

Goff completed his first 10 passes and finished 22 of 27 with 277 yards and a touchdown.

“He’s a really good quarterback — one of the best I’ve seen on film,” Tampa Bay cornerback Zyon McCollum said.

Mayfield, drafted by Cleveland in 2018, had perhaps the best season for his fourth team in three years. He had career highs with 4,044 yards passing and 28 touchdown passes in the regular season and became the first Buccaneers quarterback to throw for at least 300 yards and three touchdowns in a postseason game.

“He looks like he’s having fun like he was in college,” Tampa Bay coach Todd Bowles said. “He’s going out there playing free and playing carefree. It’s really helping him, and it’s really helping us.”

Lions defensive back C.J. Gardner-Johnson took a verbal swipe at Mayfield last week when he praised Tampa Bay’s receivers, saying they would be a great group if they had a good quarterback.

Mayfield returned some kind words and added a shot.

“He’s a good player,” Mayfield said. “But yeah, he’s just got to do a little more film study.”

SACK DANCE

Detroit defensive end Aidan Hutchinson has a chance to join a select list of players with multiple sacks in four or more consecutive games, including the playoffs. Simeon Rice had at least two sacks in five straight games while Hall of Famers Reggie White and Kevin Greene pulled off the feat in four consecutive games.

Tampa Bay rookie YaYa Diaby, a third-round pick from Louisville, has 7 1/2 sacks to lead a defense that has seven players with at least four sacks.

UNDERDOG MENTALITY

Tampa Bay is a 6 1/2-point underdog, according to FanDuel Sportsbook, after dominating the Eagles as a 2 1/2-point underdog.

“It doesn’t surprise us at all,” Bowles said. “We don’t even worry about it anymore. We kind of laugh when we see it.”

THE PREVIOUS MATCHUP

Goff threw for 353 yards and two touchdowns to help Detroit win 20-6 at Tampa Bay in Week 6. The Lions played the entire game without rookie running back Jahmyr Gibbs and veteran running back David Montgomery was out for two-plus quarters.

Mayfield was 19 of 37 passes for 206 yards with no touchdowns and one interception against the Lions.