### PR TITLE
Create recategorize-discussions workflow

### DIFF
--- a/.github/workflows/recategorize-discussions
+++ b/.github/workflows/recategorize-discussions
@@ -26,6 +26,11 @@ on:
         required: true
         # The data type of the input
         type: string
+      max_to_move:
+        description: 'The maximum number of discussions we should try to move (up to 100), helpful in testing'
+        type: number
+        default: 50
+        required: true
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -47,7 +52,7 @@ jobs:
         searchQuery="label:${{ inputs.label }} repo:${{ github.repository}}"
         discussions="$(gh api graphql -F queryString="$searchQuery" -f query='
           query($queryString: String!) {
-            search(query:$queryString,type:DISCUSSION,first:50){
+            search(query:$queryString,type:DISCUSSION,first:${{ inputs.max_to_move }}){
               nodes{
                 ...on Discussion{id}
               }

--- a/.github/workflows/recategorize-discussions
+++ b/.github/workflows/recategorize-discussions
@@ -1,0 +1,99 @@
+# This is a basic workflow that is manually triggered
+
+name: Recategorize labeled discussions
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI
+# or API.
+on:
+  workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
+      label:
+        # Friendly description to be shown in the UI instead of 'name'
+        description: 'Label for discussions that will be recategorized'
+        # Default value if no value is explicitly provided
+        default: 'bug'
+        # Input has to be provided for the workflow to run
+        required: true
+        # The data type of the input
+        type: string
+      category:
+        # Friendly description to be shown in the UI instead of 'name'
+        description: 'The name of the category the labeled discussions will be moved to'
+        # Default value if no value is explicitly provided
+        default: 'Ideas'
+        # Input has to be provided for the workflow to run
+        required: true
+        # The data type of the input
+        type: string
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "greet"
+  recategorize-discussions:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Runs a single command using the runners shell
+    - name: Send greeting
+      run: echo "Moving Discussions labeled ${{ inputs.label }} to category ${{  inputs.category }}"
+    # Use the graphql search api to find all discussions with the label using the search() query
+    - name: Find labeled discussions
+      env: 
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        searchQuery="label:${{ inputs.label }} repo:${{ github.repository}}"
+        discussions="$(gh api graphql -F queryString="$searchQuery" -f query='
+          query($queryString: String!) {
+            search(query:$queryString,type:DISCUSSION,first:50){
+              nodes{
+                ...on Discussion{id}
+              }
+            }
+          }' | jq -r '.data.search.nodes[].id')"
+        echo 'Found discussions: '"$discussions"
+        echo 'DISCUSSIONS_TO_TRANSFER='$discussions >> $GITHUB_ENV
+    - name: Find the id of the discussion category in the current repository
+      env: 
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # split github.repository into owner and name
+        repoName=$(echo ${{ github.repository }} | cut -d '/' -f 2)
+        found_category=$(gh api graphql -F name="$repoName" -F owner="${{ github.repository_owner }}" -f query='
+          query($name: String!, $owner: String!){
+            repository(owner:$owner, name:$name){
+              discussionCategories(first:100){
+                nodes{
+                  id
+                  name
+                }
+              }
+            }
+          }' | jq -r --arg category "${{ inputs.category }}" '.data.repository.discussionCategories.nodes[] | select(.name==$category) | .id')
+        echo 'CATEGORY_ID='$found_category >> $GITHUB_ENV
+    - name: Dryrun
+      env: 
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        echo "Dryrun"
+        echo "DISCUSSIONS_TO_TRANSFER=$DISCUSSIONS_TO_TRANSFER"
+        echo "CATEGORY_ID=$CATEGORY_ID"
+    - name: Move discussions
+      env: 
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # DISCUSSIONS_TO_TRANSFER is in the form "id_1 id_2 id_3"
+        # Loop over the ids and use the updateDiscussion mutation to move the discussion to the new category
+        for discussion_id in $DISCUSSIONS_TO_TRANSFER; do
+          echo "Moving discussion $discussion_id to category $CATEGORY_ID"
+          gh api graphql -F discussionId="$discussion_id" -F categoryId="$CATEGORY_ID" -f query='
+            mutation($discussionId: ID!, $categoryId: ID!) {
+              updateDiscussion(input: {discussionId: $discussionId, categoryId: $categoryId}) {
+                discussion {
+                  number
+                }
+              }
+            }'
+        done


### PR DESCRIPTION
Part of https://github.com/github/community-engagement/issues/3755

This PR adds a new manually-triggered workflow that will let folks move discussions with a given label to a new category. As-is this will rename **50** discussions at a time. I don't know exactly what the rate limits are like for this so I wanted to be a bit conservative. We can up it if needed, but I think you'll be done by then.

Here's a demo I made on my test repo:

https://github.com/community/community/assets/2043348/7a62ec03-b614-4dc2-80e9-9aaa3c1a9891


## Using it (once we've merged the PR)
1. Go to the actions tab on the repo
<img width="219" alt="CleanShot 2024-01-22 at 16 16 27@2x" src="https://github.com/community/community/assets/2043348/58f6706c-a57c-4e73-b5ff-b1f8d887f848">

2. Select the "recategorize labeled discussions" workflow on the left. Hit the "run" button on the right, fill out the form (I'm pretty sure it's case sensitive) and go!
![CleanShot 2024-01-22 at 16 16 59@2x](https://github.com/community/community/assets/2043348/6a5b03d6-1492-4bf2-b580-b287fed8b655)




