### PR TITLE
Rename a workflow from stale to dormant

### DIFF
--- a/.github/workflows/comment-on-dormant-discussions.yml
+++ b/.github/workflows/comment-on-dormant-discussions.yml
@@ -1,4 +1,4 @@
-name: Comment on stale discussions
+name: Comment on dormant discussions
 
 on: workflow_dispatch
 


### PR DESCRIPTION
As part of the project to tag and comment on dormant discussions, this PR changes the name to reflect the community's desire not to use the word `stale` and instead replaces it with `dormant`