### PR TITLE
Use the search endpoint to get the list of discussions to label and comment on

### DIFF
--- a/.github/actions/comment
+++ b/.github/actions/comment
@@ -6,7 +6,6 @@ require_relative "../lib/github"
 stale_label_id = "LA_kwDOEfmk4M8AAAABYVCU-g"
 owner = "community"
 repo = "community"
-only_these_categories = ["Copilot"]
 
 body =<<BODY
 🕒 **Discussion Activity Reminder** 🕒
@@ -24,23 +23,19 @@ Note: This dormant notification will only apply to Discussions with the `Questio
 Thank you for helping bring this Discussion to a resolution! 💬
 BODY
 
-categories = Category.all(owner:, repo:).select { |c| only_these_categories.include?(c.name) }
+discussions = Discussion.all(owner:, repo:)
+puts "All: #{discussions.count}"
 
-categories.map do |category|
-  category.discussions = Discussion.all(owner:, repo:, category:)
-end
-
-categories.each do |category|
-  category.discussions.each do |discussion|
-    puts "#{discussion.url},#{discussion.title}"
-    result = discussion.add_comment(body: body)
-    if errors = result.dig("errors")
-      puts "#{errors.dig(0, "type")}: #{errors.dig(0, "message")}"
-      sleep 1.2
-      next
-    end
-    #discussion.add_label(label_id: stale_label_id)
-
-    sleep 1.2
+unlabelled = discussions.reject { |d| d.labelled }
+puts "Unlabelled: #{unlabelled.count}"
+unlabelled.each do |discussion|
+  puts "#{discussion.url} - #{discussion.title}"
+  result = discussion.add_comment(body: body)
+  if errors = result.dig("errors")
+    puts "#{errors.dig(0, "type")}: #{errors.dig(0, "message")}"
+    exit
   end
+  discussion.add_label(label_id: stale_label_id)
+
+  sleep 10
 end

--- a/.github/lib/categories.rb
+++ b/.github/lib/categories.rb
@@ -20,6 +20,12 @@ Category = Struct.new(
           }
         }
       }
+      rateLimit {
+        limit
+        cost
+        remaining
+        resetAt
+      }
     }
     QUERY
 

--- a/.github/lib/discussions.rb
+++ b/.github/lib/discussions.rb
@@ -1,69 +1,69 @@
 # frozen_string_literal: true
 
+require "active_support"
 require "active_support/core_ext/date_and_time/calculations"
 require "active_support/core_ext/numeric/time"
 
 Discussion = Struct.new(
   :id,
   :url,
-  :title
+  :title,
+  :labelled
 ) do
-  def self.all(owner: nil, repo: nil, category: nil)
-    return [] if owner.nil? || repo.nil? || category.nil?
+  def self.all(owner: nil, repo: nil)
+    return [] if owner.nil? || repo.nil?
+
+    cutoff_date = Time.now.advance(days: -60).to_date.to_s
+    searchquery = "repo:#{owner}/#{repo} is:unanswered is:open is:unlocked updated:<#{cutoff_date} category:Copilot category:Accessibility category:\\\"Projects and Issues\\\" label:Question"
 
     query = <<~QUERY
     {
-      repository(owner: "#{owner}", name: "#{repo}"){
-        discussions(
-          first: 100,
-          after: "%ENDCURSOR%"
-          #{"answered: false," if category.answerable}
-          categoryId: "#{category.id}"
-          orderBy: { field: CREATED_AT, direction: ASC }
-        ) {
-          nodes {
-            id
-            url
-            title
-            closed
-            locked
-            updatedAt
-            comments(last: 1) {
-              totalCount
-              nodes {
-                createdAt
-              }
+      search(
+        first: 100
+        after: "%ENDCURSOR%"
+        query: "#{searchquery}"
+        type: DISCUSSION
+      ) {
+        discussionCount
+        ...Results
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+      rateLimit {
+        limit
+        cost
+        remaining
+        resetAt
+      }
+    }
+    fragment Results on SearchResultItemConnection {
+      nodes {
+        ... on Discussion {
+          id
+          url
+          title
+          labels(first: 10) {
+            nodes {
+              name
             }
-            labels(first: 100) {
-              nodes {
-                name
-              }
-            }
-          }
-          pageInfo {
-            hasNextPage
-            endCursor
           }
         }
       }
     }
     QUERY
 
-    cutoff_date = Time.now.advance(days: -60)
-    GitHub.new.post(graphql: query).map! { |r| r.dig('discussions', 'nodes') }
+    GitHub.new.post(graphql: query)
+      .map! { |r| r.dig('nodes') }
       .flatten
-      .reject { |r| Date.parse(r["updatedAt"]).after?(cutoff_date) }
-      .select { |r| r.dig("labels", "nodes").map { |l| l["name"] }.include?("Question") }
-      .reject { |r| r["closed"] }
-      .reject { |r| r["locked"] }
-      .reject { |r| r.dig("comments", "totalCount") > 0 && Date.parse(r.dig("comments", "nodes", 0, "createdAt")).after?(cutoff_date) }
-      #.reject { |r| r.dig("labels", "nodes").map { |l| l["name"] }.include?("stale") }
-      .select { |r| r.dig("labels", "nodes").map { |l| l["name"] }.include?("stale") }
       .map do |c|
+        labelled = c.dig("labels", "nodes").map { |l| l["name"] }.include?("inactive")
         Discussion.new(
           c["id"],
           c["url"],
-          c["title"]
+          c["title"],
+          labelled
         )
       end
   end

--- a/.github/lib/github.rb
+++ b/.github/lib/github.rb
@@ -14,7 +14,9 @@ class GitHub
       headers: {
         Authorization: "bearer #{ENV['GITHUB_TOKEN']}"
       }
-    )
+    ) do |f|
+      f.response :raise_error
+    end
   end
 
   def post(graphql:)
@@ -25,19 +27,21 @@ class GitHub
       query = end_cursor.nil? ? graphql.sub(/after.*\n/, "") : graphql.sub("%ENDCURSOR%", end_cursor)
 
       response = @conn.post("/graphql") do |req|
+        req.options.timeout = 10
         req.body = { query: }.to_json
       end
-      unless response.status == 200
-        puts "#{response.reason_phrase}: #{JSON.parse(response.body).dig("message")}"
-        exit
+
+      if rate_limit = JSON.parse(response.body).dig("data", "rateLimit")
+        puts "Rate limit: limit - #{rate_limit["limit"]}, cost - #{rate_limit["cost"]}, remaining - #{rate_limit["remaining"]}, resetAt - #{rate_limit["resetAt"]}"
       end
 
       node = JSON.parse(response.body).dig("data", "repository")
+      node = JSON.parse(response.body).dig("data", "search") if node.nil?
       nodes << node
 
-      break unless node.dig("discussions", "pageInfo", "hasNextPage")
+      break unless node&.dig("pageInfo", "hasNextPage")
 
-      end_cursor = node.dig("discussions", "pageInfo", "endCursor")
+      end_cursor = node.dig("pageInfo", "endCursor")
     end
 
     nodes.flatten

--- a/.github/workflows/comment-on-dormant-discussions.yml
+++ b/.github/workflows/comment-on-dormant-discussions.yml
@@ -1,6 +1,10 @@
 name: Comment on dormant discussions
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  schedule:
+    # At minute 23 past every 2nd hour
+    - cron: '23 */2 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
This is less intensive and should keep things under the primary rate limits, even as more categories are added in.

I've also put in a `sleep` for 10 seconds to try and stay under the [secondary rate limits](https://docs.github.com/graphql/overview/rate-limits-and-node-limits-for-the-graphql-api#secondary-rate-limits) too