### PR TITLE
Update the version of setup-ruby

### DIFF
--- a/.github/workflows/comment-on-dormant-discussions.yml
+++ b/.github/workflows/comment-on-dormant-discussions.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+        uses: ruby/setup-ruby@5f19ec79cedfadb78ab837f95b87734d0003c899
 
       - name: Bundle install
         run: bundle install


### PR DESCRIPTION
The workflow runs were showing an error that node v16 actions are deprecated. This changes updates to the latest version of setup-ruby which has fixed this warning

<img width="1149" alt="Screenshot 2024-03-22 at 09 27 22" src="https://github.com/community/community/assets/17725/897758ca-0aa6-44ec-9d14-0c79a1308fb4">
