### PR TITLE
Add an action to remove the inactive label when a discussion is commented on

### DIFF
--- a/.github/actions/remove_label
+++ b/.github/actions/remove_label
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/github"
+
+stale_label_id = "LA_kwDOEfmk4M8AAAABYVCU-g"
+owner = "community"
+repo = "community"
+
+node_id = ENV['NODE_ID']
+puts "Removing the inactive label from #{node_id}"
+Discussion.remove_label(node_id: node_id, label_id: stale_label_id)

--- a/.github/lib/discussions.rb
+++ b/.github/lib/discussions.rb
@@ -109,4 +109,25 @@ Discussion = Struct.new(
 
     GitHub.new.mutate(graphql: query)
   end
+
+  def self.remove_label(node_id: nil, label_id: nil)
+    return if node_id.nil?
+    return if label_id.nil?
+
+    query = <<~QUERY
+    mutation {
+      removeLabelsFromLabelable(
+        input: {
+          labelIds: ["#{label_id}"],
+          labelableId: "#{node_id}",
+          clientMutationId: "rubyGraphQL"
+        }
+      ) {
+        clientMutationId
+      }
+    }
+    QUERY
+
+    GitHub.new.mutate(graphql: query)
+  end
 end


### PR DESCRIPTION
This is part of the inactive bot project. If a discussion has been commented on and labelled by the bot, there's a grace period of 30 days before the discussion is closed. If the discussion gets a comment in this time, then this action and script will remove the label from the discussion.

This uses the `discussion_comment` webhook which triggers the action workflow.