### PR TITLE
Add an action to close dormant discussions

### DIFF
--- a/.github/actions/close
+++ b/.github/actions/close
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/github"
+
+stale_label_id = "LA_kwDOEfmk4M8AAAABYVCU-g"
+owner = "community"
+repo = "community"
+
+discussions = Discussion.to_be_closed(owner:, repo:)
+puts "All: #{discussions.count}"
+
+discussions.each do |discussion|
+  puts "#{discussion.url} - #{discussion.title}"
+  result = discussion.close_as_outdated
+  if errors = result.dig("errors")
+    puts "#{errors.dig(0, "type")}: #{errors.dig(0, "message")}"
+    exit
+  end
+
+  sleep 10
+end

--- a/.github/lib/discussions.rb
+++ b/.github/lib/discussions.rb
@@ -68,6 +68,133 @@ Discussion = Struct.new(
       end
   end
 
+  def self.to_be_closed(owner: nil, repo: nil)
+    return [] if owner.nil? || repo.nil?
+
+    cutoff_date = Time.now.advance(days: -30).to_date.to_s
+    searchquery = "repo:#{owner}/#{repo} is:unanswered is:open is:unlocked updated:<#{cutoff_date} category:Copilot category:Accessibility category:\\\"Projects and Issues\\\" label:Question label:inactive"
+
+    query = <<~QUERY
+    {
+      search(
+        first: 100
+        after: "%ENDCURSOR%"
+        query: "#{searchquery}"
+        type: DISCUSSION
+      ) {
+        discussionCount
+        ...Results
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+      rateLimit {
+        limit
+        cost
+        remaining
+        resetAt
+      }
+    }
+    fragment Results on SearchResultItemConnection {
+      nodes {
+        ... on Discussion {
+          id
+          url
+          title
+          comments(last:1) {
+            nodes {
+              author {
+                login
+              }
+            }
+          }
+          labels(first: 10) {
+            nodes {
+              name
+            }
+          }
+        }
+      }
+    }
+    QUERY
+
+    GitHub.new.post(graphql: query)
+      .map! { |r| r.dig('nodes') }
+      .flatten
+      .select { |c| c.dig("comments", "nodes", 0, "author", "login") == "github-actions" }
+      .map do |c|
+        Discussion.new(
+          c["id"],
+          c["url"],
+          c["title"],
+        )
+      end
+  end
+
+  def self.to_remove_label(owner: nil, repo: nil)
+    return [] if owner.nil? || repo.nil?
+
+    searchquery = "repo:#{owner}/#{repo} is:unanswered is:open category:Copilot category:Accessibility category:\\\"Projects and Issues\\\" label:Question label:inactive"
+
+    query = <<~QUERY
+    {
+      search(
+        first: 100
+        after: "%ENDCURSOR%"
+        query: "#{searchquery}"
+        type: DISCUSSION
+      ) {
+        discussionCount
+        ...Results
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+      rateLimit {
+        limit
+        cost
+        remaining
+        resetAt
+      }
+    }
+    fragment Results on SearchResultItemConnection {
+      nodes {
+        ... on Discussion {
+          id
+          url
+          title
+          comments(last:1) {
+            nodes {
+              author {
+                login
+              }
+            }
+          }
+          labels(first: 10) {
+            nodes {
+              name
+            }
+          }
+        }
+      }
+    }
+    QUERY
+
+    GitHub.new.post(graphql: query)
+      .map! { |r| r.dig('nodes') }
+      .flatten
+      .reject { |c| c.dig("comments", "nodes", 0, "author", "login") == "github-actions" }
+      .map do |c|
+        Discussion.new(
+          c["id"],
+          c["url"],
+          c["title"],
+        )
+      end
+  end
+
   def add_comment(body: nil)
     query = <<~QUERY
     mutation {
@@ -120,6 +247,24 @@ Discussion = Struct.new(
         input: {
           labelIds: ["#{label_id}"],
           labelableId: "#{node_id}",
+          clientMutationId: "rubyGraphQL"
+        }
+      ) {
+        clientMutationId
+      }
+    }
+    QUERY
+
+    GitHub.new.mutate(graphql: query)
+  end
+
+  def close_as_outdated
+    query = <<~QUERY
+    mutation {
+      closeDiscussion(
+        input: {
+          discussionId: "#{self.id}",
+          reason: OUTDATED,
           clientMutationId: "rubyGraphQL"
         }
       ) {

--- a/.github/workflows/close-dormant-discussions.yml
+++ b/.github/workflows/close-dormant-discussions.yml
@@ -1,0 +1,29 @@
+name: Close out dormant discussions
+
+on:
+  workflow_dispatch:
+  schedule:
+    # At 01:23 every day
+    - cron: '23 1 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      discussions: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@5f19ec79cedfadb78ab837f95b87734d0003c899
+
+      - name: Bundle install
+        run: bundle install
+
+      - name: Close out discussions
+        run: .github/actions/close
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/comment-on-dormant-discussions.yml
+++ b/.github/workflows/comment-on-dormant-discussions.yml
@@ -3,8 +3,8 @@ name: Comment on dormant discussions
 on:
   workflow_dispatch:
   schedule:
-    # At minute 23 past every 2nd hour
-    - cron: '23 */2 * * *'
+    # At 03:23 every day
+    - cron: '23 3 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
Discussions that have been labelled as `inactive` should go through another round of checks after 30 days. If they haven't received any activity in this time, and are still open, then this action will close them out with a reason of `OUTDATED`.

The workflow will run once a day at 01:23 (chosen arbitrarily by me). I've made another change to the comment workflow too, changing that to run once a day at 03:23 instead of every two hours