### PR TITLE
There are underscores in the file name

### DIFF
--- a/.github/workflows/remove-inactive-label.yml
+++ b/.github/workflows/remove-inactive-label.yml
@@ -21,7 +21,7 @@ jobs:
         run: bundle install
 
       - name: Remove the label
-        run: .github/actions/remove-inactive-label
+        run: .github/actions/remove_inactive_label
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_ID: ${{ github.event.discussion.node_id }}


### PR DESCRIPTION
And not dashes!

This fixes the workflow that removes the inactive label by calling the proper named file