### PR TITLE
REXML contains a denial of service vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,8 @@ GEM
     rack (3.0.9.1)
     rainbow (3.1.1)
     regexp_parser (2.9.0)
-    rexml (3.2.6)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
     rubocop (1.62.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -64,6 +65,7 @@ GEM
       rubocop (>= 1.33.0, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
+    strscan (3.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -71,6 +73,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   faraday


### PR DESCRIPTION
The REXML gem before 3.2.6 has a DoS vulnerability when it parses an XML that has many <s in an attribute value.

If you need to parse untrusted XMLs, you many be impacted to this vulnerability.