### PR TITLE
Upgrade github-script Action to v7 to use Node v20

### DIFF
--- a/.github/workflows/Accessibility-Labeler.yml
+++ b/.github/workflows/Accessibility-Labeler.yml
@@ -34,7 +34,7 @@ jobs:
       
       - name: Get selected topic
         id: get_selected_topic
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/auto-close-pr.yml
+++ b/.github/workflows/auto-close-pr.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Check if employee
         id: check_employee
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.READ_GITHUB_ORG_MEMBERS_TOKEN }}
           result-encoding: string
@@ -36,7 +36,7 @@ jobs:
       - name: Close PR
         id: close_pr
         if: ${{ steps.check_employee.outputs.result == 'false' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/issue_projects_labeler.yml
+++ b/.github/workflows/issue_projects_labeler.yml
@@ -34,7 +34,7 @@ jobs:
       
       - name: Get selected topic
         id: get_selected_topic
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/label-templated-discussions.yml
+++ b/.github/workflows/label-templated-discussions.yml
@@ -34,7 +34,7 @@ jobs:
       
       - name: Get selected topic
         id: get_selected_topic
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/remove-governed-labels-on-create.yml
+++ b/.github/workflows/remove-governed-labels-on-create.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Check if employee
         id: check_employee
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.READ_GITHUB_ORG_MEMBERS_TOKEN }}
           result-encoding: string

--- a/.github/workflows/remove-governed-labels-on-label.yml
+++ b/.github/workflows/remove-governed-labels-on-label.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Check if employee
         id: check_employee
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.READ_GITHUB_ORG_MEMBERS_TOKEN }}
           result-encoding: string


### PR DESCRIPTION
This PR upgrades each of the references to `actions/github-script` to use version 7 which internally upgrades to use Node v20. It should be a straight upgrade, without any problems 🤞 

### References

- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
- https://github.com/actions/github-script/releases/tag/v7.0.0