### PR TITLE
Generalise the version of setup-ruby action

### DIFF
--- a/.github/workflows/add-feedback-comment.yml
+++ b/.github/workflows/add-feedback-comment.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+        uses: ruby/setup-ruby@v1
 
       - name: Bundle install
         run: bundle install

--- a/.github/workflows/close-dormant-discussions.yml
+++ b/.github/workflows/close-dormant-discussions.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@5f19ec79cedfadb78ab837f95b87734d0003c899
+        uses: ruby/setup-ruby@v1
 
       - name: Bundle install
         run: bundle install

--- a/.github/workflows/comment-on-dormant-discussions.yml
+++ b/.github/workflows/comment-on-dormant-discussions.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@5f19ec79cedfadb78ab837f95b87734d0003c899
+        uses: ruby/setup-ruby@v1
 
       - name: Bundle install
         run: bundle install

--- a/.github/workflows/remove-inactive-label.yml
+++ b/.github/workflows/remove-inactive-label.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+        uses: ruby/setup-ruby@v1
 
       - name: Bundle install
         run: bundle install


### PR DESCRIPTION
Instead of pinning to a specific SHA and having to remember to keep that up to date, this PR instead pins to version 1 and lets the upgrades happen as they come