### PR TITLE
GraphQL requires triple quotes for multi line strings

### DIFF
--- a/.github/lib/discussions.rb
+++ b/.github/lib/discussions.rb
@@ -200,7 +200,7 @@ Discussion = Struct.new(
     mutation {
       addDiscussionComment(
         input: {
-          body: "#{body}",
+          body: """#{body}""",
           discussionId: "#{self.id}",
           clientMutationId: "rubyGraphQL"
         }


### PR DESCRIPTION
Looking at the GraphQL spec, we should be wrapping multi line body strings in three sets of double quotes and not just one to correctly send the body text (https://spec.graphql.org/October2021/#sec-String-Value)

