### PR TITLE
[incident discussion automation] `discussion` -> `discussions` file name typo correction

### DIFF
--- a/.github/actions/close_incident_discussions.rb
+++ b/.github/actions/close_incident_discussions.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require_relative "../lib/github"
-require_relative "../lib/discussion"
+require_relative "../lib/discussions"
 require "active_support"
 require "active_support/core_ext/date_and_time/calculations"
 require "active_support/core_ext/numeric/time"

--- a/.github/actions/open_incident_discussion.rb
+++ b/.github/actions/open_incident_discussion.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require_relative "../lib/github"
-require_relative "../lib/discussion"
+require_relative "../lib/discussions"
 require "active_support/core_ext/date_time"
 
 # This script takes context from a received webhook and creates a new discussion in the correct discussion category

--- a/.github/actions/post_incident_summary.rb
+++ b/.github/actions/post_incident_summary.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require_relative "../lib/github"
-require_relative "../lib/discussion"
+require_relative "../lib/discussions"
 
 # This script takes the public incident summary, adds it as a comment to the incident, and then marks that comment as the answer.
 

--- a/.github/actions/update_incident_discussion.rb
+++ b/.github/actions/update_incident_discussion.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require_relative "../lib/github"
-require_relative "../lib/discussion"
+require_relative "../lib/discussions"
 
 # This script takes the context from the latest update dispatch event and updates the active incident discussion
 


### PR DESCRIPTION
In the testing environment, I had unintentionally named the lib file `discussion.rb` instead of `discussions.rb`, and thus when the test run of the `close-incident-discussions` workflow ran as scheduled, it errored out due to the missing file. This PR corrects that typo!

cc @mgriffin 🙈