### PR TITLE
[Incident Discussion Automation] Updating logic to exit early if no discussion found

### DIFF
--- a/.github/actions/close_incident_discussions.rb
+++ b/.github/actions/close_incident_discussions.rb
@@ -13,7 +13,7 @@ require "date"
 discussions = Discussion.find_open_incident_discussions(owner: "community", repo: "community").keep_if { |d| DateTime.parse(d.created_at) < 2.days.ago }
 
 if discussions.length == 0
-  puts "No discussion IDs provided, exiting"
+  puts "No applicable discussions found, exiting"
   exit
 end
 

--- a/.github/actions/post_incident_summary.rb
+++ b/.github/actions/post_incident_summary.rb
@@ -9,6 +9,11 @@ require_relative "../lib/discussions"
 # first, we must identify the correct incident to update, in the case where there are multiple open incident discussions.
 selected_discussion = Discussion.find_open_incident_discussions(owner: "community", repo: "community").keep_if { |d| d.body.include?("#{ENV["INCIDENT_SLUG"]}") }.first
 
+if selected_discussion.nil?
+  puts "No applicable discussion, exiting"
+  exit
+end
+
 # add the summary as a comment to the discussion
 summary = "### Incident Summary \n #{ENV["INCIDENT_PUBLIC_SUMMARY"]}"
 comment_id = selected_discussion.add_comment(body: summary).dig("data", "addDiscussionComment", "comment", "id")

--- a/.github/actions/update_incident_discussion.rb
+++ b/.github/actions/update_incident_discussion.rb
@@ -9,6 +9,11 @@ require_relative "../lib/discussions"
 # first, we must identify the correct incident to update, in the case where there are multiple open incident discussions.
 discussion = Discussion.find_open_incident_discussions(owner: "community", repo: "community").keep_if { |d| d.body.include?("#{ENV["INCIDENT_SLUG"]}") }.first
 
+if discussion.nil?
+  puts "No applicable discussion, exiting"
+  exit
+end
+
 # next, we need to update the discussion with the new information
 update = "### Update \n #{ENV["INCIDENT_MESSAGE"]}"
 


### PR DESCRIPTION
On Friday, we received a `repository_dispatch` event for an incident that began before the actions were deployed for the first time, meaning it did not have a corresponding discussion. 
This appeared in Slack as a workflow failure; we can instead exit early if there is no corresponding discussion for an update or summary action rather than allow the action to error out. This will reduce the amount of failed workflows reported.  

This PR also updates the wording on the early exit on the close action to more accurately reflect the exit condition. 