### PR TITLE
[Incident Discussion Automation] add workflow for 'incident-resolved' event type

### DIFF
--- a/.github/actions/close_incident_discussions.rb
+++ b/.github/actions/close_incident_discussions.rb
@@ -26,7 +26,7 @@ discussions.each do |d|
       Discussion.mark_comment_as_answer(comment_id:)
     end
 
-    updated_body = "![A dark background with two security-themed abstract shapes positioned in the top left and bottom right corners. In the center of the image, bold white text reads \\\"Incident Resolved\\\" with a white Octocat logo.](https://github.com/community/incident-discussion-bot/blob/main/.github/src/incident_resolved.png?raw=true) \n #{d.body}"
+    updated_body = "![A dark background with two security-themed abstract shapes positioned in the top left and bottom right corners. In the center of the image, bold white text reads \\\"Incident Resolved\\\" with a white Octocat logo.](https://github.com/community/community/blob/main/.github/src/incident_resolved.png?raw=true) \n #{d.body}"
     d.update_discussion(body: updated_body)
   end
 

--- a/.github/actions/post_incident_summary.rb
+++ b/.github/actions/post_incident_summary.rb
@@ -22,6 +22,8 @@ comment_id = selected_discussion.add_comment(body: summary).dig("data", "addDisc
 # (note that we don't need the discussion's context for this, so we don't call it on the instance of Discussion but on the struct)
 Discussion.mark_comment_as_answer(comment_id:)
 
-# update the post body to include the resolved picture
-updated_body = "![A dark background with two security-themed abstract shapes positioned in the top left and bottom right corners. In the center of the image, bold white text reads \\\"Incident Resolved\\\" with a white Octocat logo.](https://github.com/community/incident-discussion-bot/blob/main/.github/src/incident_resolved.png?raw=true) \n \n #{selected_discussion.body}"
-selected_discussion.update_discussion(body: updated_body)
+# update the post body to include the resolved picture, but only if the post body has not already been updated.
+unless selected_discussion.body.include?("https://github.com/community/community/blob/main/.github/src/incident_resolved.png?raw=true")
+  updated_body = "![A dark background with two security-themed abstract shapes positioned in the top left and bottom right corners. In the center of the image, bold white text reads \\\"Incident Resolved\\\" with a white Octocat logo.](https://github.com/community/community/blob/main/.github/src/incident_resolved.png?raw=true) \n \n #{selected_discussion.body}"
+  selected_discussion.update_discussion(body: updated_body)
+end

--- a/.github/actions/resolve_incident_discussion.rb
+++ b/.github/actions/resolve_incident_discussion.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/github"
+require_relative "../lib/discussions"
+
+# This script acts when we receieve an incident resolved dispatch event to update the incident discussion.
+
+# first, we must identify the correct incident to update, in the case where there are multiple open incident discussions.
+discussion = Discussion.find_open_incident_discussions(owner: "community", repo: "community").keep_if { |d| d.body.include?("#{ENV["INCIDENT_SLUG"]}") }.first
+
+discussion.add_comment(body: "### Incident Resolved \n This incident has been resolved.")
+# update the post body to include the resolved picture
+updated_body = "![A dark background with two security-themed abstract shapes positioned in the top left and bottom right corners. In the center of the image, bold white text reads \\\"Incident Resolved\\\" with a white Octocat logo.](https://github.com/community/community/blob/main/.github/src/incident_resolved.png?raw=true) \n \n #{discussion.body}"
+discussion.update_discussion(body: updated_body)

--- a/.github/workflows/update-incident-discussion-as-resolved.yml
+++ b/.github/workflows/update-incident-discussion-as-resolved.yml
@@ -1,0 +1,39 @@
+name: Mark incident discussion as resolved
+
+on:
+  repository_dispatch:
+    types: [incident-resolved]
+
+jobs:
+  resolve_discussion:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      discussions: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@7bae1d00b5db9166f4f0fc47985a3a5702cb58f0
+
+      - name: Bundle install
+        run: bundle install
+
+      - name: Get incident URL slug
+        id: incident_slug
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const url = "${{ github.event.client_payload.incidentLink }}"
+            const slug = url.split('/').pop();
+            return slug
+
+      - name: Mark incident discussion as resolved
+        id: mark_resolved
+        run: .github/actions/resolve_incident_discussion.rb
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INCIDENT_SLUG: ${{ steps.incident_slug.outputs.result }}


### PR DESCRIPTION
Happy New Year!

We weren't catching the `incident-resolved` repository dispatch event from the status page, which is emitted when an ongoing incident is marked as resolved. This PR adds a workflow that listens for this event and triggers the `resolve_incident_discussion.rb` script, which adds a generic "This incident has been resolved" comment (as we receive no custom comment from the status page for this event) and updates the post body with the "incident resolved" graphic. 

To accommodate this change, I've also updated the `post_incident_summary.rb` script to include the resolved picture in the post body only if it hasn't already been updated. Finally, I noticed the URL for the "incident resolved" image was pointing to the test repo, so I've updated that URL as well just in case of future drift between the test environment and this environment. 