### PR TITLE
Update resolve_incident_discussion.rb to exit early

### DIFF
--- a/.github/actions/resolve_incident_discussion.rb
+++ b/.github/actions/resolve_incident_discussion.rb
@@ -9,6 +9,11 @@ require_relative "../lib/discussions"
 # first, we must identify the correct incident to update, in the case where there are multiple open incident discussions.
 discussion = Discussion.find_open_incident_discussions(owner: "community", repo: "community").keep_if { |d| d.body.include?("#{ENV["INCIDENT_SLUG"]}") }.first
 
+if discussion.nil?
+  puts "No applicable discussion, exiting"
+  exit
+end
+
 discussion.add_comment(body: "### Incident Resolved \n This incident has been resolved.")
 # update the post body to include the resolved picture
 updated_body = "![A dark background with two security-themed abstract shapes positioned in the top left and bottom right corners. In the center of the image, bold white text reads \\\"Incident Resolved\\\" with a white Octocat logo.](https://github.com/community/community/blob/main/.github/src/incident_resolved.png?raw=true) \n \n #{discussion.body}"


### PR DESCRIPTION
When I added this workflow, I missed adding the early exit if no discussion is found. Not exiting early results in errors surfacing if the discussion can't be found, which happened during an instance of two concurrent incidents. This PR adds the early exit logic.