### PR TITLE
Update close_incident_discussions.rb

### DIFF
--- a/.github/actions/close_incident_discussions.rb
+++ b/.github/actions/close_incident_discussions.rb
@@ -26,8 +26,11 @@ discussions.each do |d|
       Discussion.mark_comment_as_answer(comment_id:)
     end
 
-    updated_body = "![A dark background with two security-themed abstract shapes positioned in the top left and bottom right corners. In the center of the image, bold white text reads \\\"Incident Resolved\\\" with a white Octocat logo.](https://github.com/community/community/blob/main/.github/src/incident_resolved.png?raw=true) \n #{d.body}"
-    d.update_discussion(body: updated_body)
+    # an incident that has been declared as "resolved" should have already updated the post body, this is in case that step failed.
+    unless d.body.include?("https://github.com/community/community/blob/main/.github/src/incident_resolved.png?raw=true")
+      updated_body = "![A dark background with two security-themed abstract shapes positioned in the top left and bottom right corners. In the center of the image, bold white text reads \\\"Incident Resolved\\\" with a white Octocat logo.](https://github.com/community/community/blob/main/.github/src/incident_resolved.png?raw=true) \n #{d.body}"
+      d.update_discussion(body: updated_body)
+    end
   end
 
   d.close_as_resolved


### PR DESCRIPTION
It occurred to me when I updated the workflow logic in https://github.com/community/community/pull/148652 that I missed adding this check to the `close_incident_discussions` action. This PR ensures that we don't end up unintentionally posting the "Incident Resolved" image twice.