### PR TITLE
[Close Incident Discussions] Reject early if comment author is nil

### DIFF
--- a/.github/lib/discussions.rb
+++ b/.github/lib/discussions.rb
@@ -443,7 +443,7 @@ Discussion = Struct.new(
 
     return nil if comments.empty?
 
-    filtered_comments = comments.keep_if { |comment| comment["author"]["login"] == actor_login }
+    filtered_comments = comments.keep_if { |comment| comment["author"] && comment["author"]["login"] == actor_login }
                         &.sort_by { |comment| comment["createdAt"] }
                         .reverse
 


### PR DESCRIPTION
I noticed that over the weekend, the `close_incident_discussion` workflow started failing unexpectedly. 

The error produced was:

```
/home/runner/work/community/community/.github/lib/discussions.rb:446:in `block in find_most_recent_incident_comment_id': undefined method `[]' for nil (NoMethodError)

    filtered_comments = comments.keep_if { |comment| comment["author"]["login"] == actor_login }
                                                                      ^^^^^^^^^
	from /home/runner/work/community/community/.github/lib/discussions.rb:446:in `keep_if'
	from /home/runner/work/community/community/.github/lib/discussions.rb:446:in `find_most_recent_incident_comment_id'
	from .github/actions/close_incident_discussions.rb:23:in `block in <main>'
	from .github/actions/close_incident_discussions.rb:20:in `each'
	from .github/actions/close_incident_discussions.rb:20:in `<main>'
```

It turns out that when a user is deleted, the `author` results in `null`, and there was a comment on an open incident discussion from a now-deleted user that was causing the automation to fail here:

https://github.com/community/community/blob/main/.github/lib/discussions.rb#L445-449

```
    filtered_comments = comments.keep_if { |comment| comment["author"] && comment["author"]["login"] == actor_login }
                        &.sort_by { |comment| comment["createdAt"] }
                        .reverse
```
To resolve this, we now reject potential comments early if they don't have an author associated before continuing to filter down based on author login.

Here's an example of the workflow succeeding with this change:
https://github.com/community/community/actions/runs/17211906149/job/48825621194