### PR TITLE
Rename Copilot Coding Agent to Copilot Cloud Agent

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/copilot-conversations.yml
+++ b/.github/DISCUSSION_TEMPLATE/copilot-conversations.yml
@@ -26,7 +26,7 @@ body:
       - Copilot in GitHub
       - Copilot Workspace
       - Copilot Agent Mode
-      - Copilot Coding Agent
+      - Copilot Cloud Agent
       - Copilot Enterprise
       - Account Related
       - VS Code


### PR DESCRIPTION
As of 3/31, Copilot Coding Agent (CCA) has been renamed to Copilot Cloud Agent