### PR TITLE
Fix label formatting in discussion template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/actions.yml
+++ b/.github/DISCUSSION_TEMPLATE/actions.yml
@@ -55,7 +55,7 @@ body:
     required: true
 - type: textarea
   attributes:
-    label: Discussion Details
+    label: "Discussion Details"
     description: >-
       Share your question, feedback, or story! Include links, code, or screenshots for more context. Tip: Reference the docs https://docs.github.com/en/actions or relevant changelogs for details.
   validations:


### PR DESCRIPTION
This pull request makes a minor update to the `.github/DISCUSSION_TEMPLATE/actions.yml` file by adding quotation marks around the "Discussion Details" label for consistency.

- Standardized the `label` field in the discussion template by enclosing "Discussion Details" in quotes.